### PR TITLE
Fix path in the MDI mechanic file for Psi4 Python

### DIFF
--- a/mdimechanic.yml
+++ b/mdimechanic.yml
@@ -34,6 +34,7 @@ run_scripts:
       ani-tutorial:
         image: 'mdi-ani-tutorial:dev'
         script:
+          - export PATH="/root/psi4conda/bin":$PATH
           - python mdi-ani-tutorial/mdi-ani-tutorial.py -mdi "-role DRIVER -name driver -method TCP -port 8021"
       lammps:
         image: 'janash/mdi-lammps:tutorial'


### PR DESCRIPTION
This should edit the path to use the psi4conda `bin` path in the images to have the Codespace work again.