### PR TITLE
Start with NumPy imported

### DIFF
--- a/mdi-ani-tutorial/mdi-ani-tutorial.py
+++ b/mdi-ani-tutorial/mdi-ani-tutorial.py
@@ -4,6 +4,9 @@ import warnings
 # Import the MDI Library
 import mdi
 
+# Import Numpy
+import numpy as np
+
 # Import MPI Library
 try:
     from mpi4py import MPI


### PR DESCRIPTION
This starts the tutorial with NumPy imported so that they don't forget to import it later and have issues in the tutorial which are obscured from non-captured `docker compose up` commands if you just run MDI Mechanic